### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -17,7 +17,7 @@ displayRightDigit	KEYWORD2
 display_both	KEYWORD2
 displayDigits	KEYWORD2
 showLeadingZero	KEYWORD2
-showLeftDecimal KEYWORD2
+showLeftDecimal	KEYWORD2
 showRightDecimal	KEYWORD2
 getKey			KEYWORD2
 getKeyReading	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords